### PR TITLE
Button up Authorization Permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,18 @@ python manage_migrations.py db migrate -m "Relevant note describing the schema c
 # double check the ugrade and downgrade changes in the new revision file created in `migrations/versions`
 python manage_migrations.py db upgrade
 ```
+
+
+Interact with database locally in python shell
+```bash
+docker exec -it road-to-nowhere-web bash
+# create app
+from road_to_nowhere.app import create_app
+from road_to_nowhere.database import db
+from road_to_nowhere.models import UserModel
+app = create_app()
+with app.app_context():
+    users = db.session.query(UserModel).all()
+    for user in users:
+        print(user.username)
+```

--- a/road_to_nowhere/app.py
+++ b/road_to_nowhere/app.py
@@ -20,7 +20,7 @@ def create_app():
     # login manager required configs
     login = LoginManager(app)
 
-    # takes user id from curent session and logs them in
+    # takes user id from current session and logs them in
     @login.user_loader
     def load_user(id):
         return UserModel.query.get(int(id))

--- a/road_to_nowhere/auth/auth_routes.py
+++ b/road_to_nowhere/auth/auth_routes.py
@@ -2,7 +2,7 @@ import json
 
 from cryptography.exceptions import InvalidKey
 from flask import Blueprint
-from flask_login import current_user, login_user, logout_user
+from flask_login import current_user, login_user, login_required, logout_user
 
 from road_to_nowhere.auth.auth_helpers import add_user, get_user, get_user_data
 from road_to_nowhere.exceptions import DatabaseRoadToNowhereError
@@ -10,7 +10,9 @@ from road_to_nowhere.exceptions import DatabaseRoadToNowhereError
 bp = Blueprint('auth_manager', __name__)
 
 
-@bp.route('/register-user', methods=['POST'])
+@bp.route('/register-new-user', methods=['POST'])
+# only a logged in user should be able to register new users
+@login_required
 def register():
     username, password = get_user_data()
     if not username or not password:
@@ -43,6 +45,7 @@ def login():
 
 
 @bp.route('/logout', methods=['GET'])
+@login_required
 def logout():
     logout_user()
     return {'message': 'Logged out'}, 200


### PR DESCRIPTION
Registered users can only be created by a logged in user. It still allows a registration endpoint
to exist but doesn't make the endpoint (completely) public